### PR TITLE
Add group management screens and API service

### DIFF
--- a/frontend/lib/main.dart
+++ b/frontend/lib/main.dart
@@ -1,0 +1,17 @@
+import 'package:flutter/material.dart';
+import 'screens/main_layout.dart';
+
+void main() {
+  runApp(const MyApp());
+}
+
+class MyApp extends StatelessWidget {
+  const MyApp({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return const MaterialApp(
+      home: MainLayout(),
+    );
+  }
+}

--- a/frontend/lib/screens/group_create_join_screen.dart
+++ b/frontend/lib/screens/group_create_join_screen.dart
@@ -1,0 +1,95 @@
+import 'package:flutter/material.dart';
+import '../services/apis/groups_api.dart';
+
+class GroupCreateJoinScreen extends StatefulWidget {
+  const GroupCreateJoinScreen({super.key});
+
+  @override
+  State<GroupCreateJoinScreen> createState() => _GroupCreateJoinScreenState();
+}
+
+class _GroupCreateJoinScreenState extends State<GroupCreateJoinScreen> {
+  final GroupsApi api = GroupsApi();
+  final TextEditingController _nameCtrl = TextEditingController();
+  final TextEditingController _codeCtrl = TextEditingController();
+  bool _loading = false;
+  String? _joinError;
+
+  @override
+  void dispose() {
+    _nameCtrl.dispose();
+    _codeCtrl.dispose();
+    super.dispose();
+  }
+
+  Future<void> _create() async {
+    setState(() => _loading = true);
+    try {
+      await api.createGroup(_nameCtrl.text);
+      if (!mounted) return;
+      Navigator.pop(context, true);
+    } catch (e) {
+      ScaffoldMessenger.of(context)
+          .showSnackBar(SnackBar(content: Text('Could not create group: $e')));
+    } finally {
+      if (mounted) setState(() => _loading = false);
+    }
+  }
+
+  Future<void> _join() async {
+    setState(() {
+      _loading = true;
+      _joinError = null;
+    });
+    try {
+      await api.joinGroup(_codeCtrl.text);
+      if (!mounted) return;
+      Navigator.pop(context, true);
+    } on InvalidInviteCodeException {
+      setState(() => _joinError = 'Invalid invite code');
+    } catch (_) {
+      setState(() => _joinError = 'Failed to join group');
+    } finally {
+      if (mounted) setState(() => _loading = false);
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Create or Join Group')),
+      body: AbsorbPointer(
+        absorbing: _loading,
+        child: Padding(
+          padding: const EdgeInsets.all(16),
+          child: Column(
+            children: [
+              TextField(
+                controller: _nameCtrl,
+                decoration: const InputDecoration(labelText: 'Group name'),
+              ),
+              const SizedBox(height: 8),
+              ElevatedButton(
+                onPressed: _create,
+                child: const Text('Create'),
+              ),
+              const Divider(height: 32),
+              TextField(
+                controller: _codeCtrl,
+                decoration: InputDecoration(
+                  labelText: 'Invite code',
+                  errorText: _joinError,
+                ),
+              ),
+              const SizedBox(height: 8),
+              ElevatedButton(
+                onPressed: _join,
+                child: const Text('Join'),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/frontend/lib/screens/group_detail_screen.dart
+++ b/frontend/lib/screens/group_detail_screen.dart
@@ -1,0 +1,65 @@
+import 'package:flutter/material.dart';
+import '../services/apis/groups_api.dart';
+
+class GroupDetailScreen extends StatefulWidget {
+  final String groupId;
+  const GroupDetailScreen({super.key, required this.groupId});
+
+  @override
+  State<GroupDetailScreen> createState() => _GroupDetailScreenState();
+}
+
+class _GroupDetailScreenState extends State<GroupDetailScreen> {
+  final GroupsApi api = GroupsApi();
+  late Future<Map<String, dynamic>> _group;
+
+  @override
+  void initState() {
+    super.initState();
+    _group = api.fetchGroupDetail(widget.groupId);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Group Detail')),
+      body: FutureBuilder<Map<String, dynamic>>(
+        future: _group,
+        builder: (context, snapshot) {
+          if (snapshot.connectionState != ConnectionState.done) {
+            return const Center(child: CircularProgressIndicator());
+          }
+          if (snapshot.hasError) {
+            return Center(child: Text('Error: ${snapshot.error}'));
+          }
+          final g = snapshot.data ?? {};
+          final members = g['members'] as List<dynamic>? ?? [];
+          final isOwner = g['isOwner'] == true;
+          return ListView(
+            padding: const EdgeInsets.all(16),
+            children: [
+              Text(
+                g['name'] ?? 'Group',
+                style: Theme.of(context).textTheme.headlineSmall,
+              ),
+              const SizedBox(height: 16),
+              Text('Members', style: Theme.of(context).textTheme.titleMedium),
+              ...members.map((m) => ListTile(title: Text(m['name'] ?? 'Member'))),
+              const SizedBox(height: 24),
+              if (isOwner)
+                ElevatedButton(
+                  onPressed: () {},
+                  child: const Text('Manage Group'),
+                )
+              else
+                ElevatedButton(
+                  onPressed: () {},
+                  child: const Text('Leave Group'),
+                ),
+            ],
+          );
+        },
+      ),
+    );
+  }
+}

--- a/frontend/lib/screens/group_list_screen.dart
+++ b/frontend/lib/screens/group_list_screen.dart
@@ -1,0 +1,82 @@
+import 'package:flutter/material.dart';
+import '../services/apis/groups_api.dart';
+import 'group_detail_screen.dart';
+import 'group_create_join_screen.dart';
+
+class GroupListScreen extends StatefulWidget {
+  const GroupListScreen({super.key});
+
+  @override
+  State<GroupListScreen> createState() => _GroupListScreenState();
+}
+
+class _GroupListScreenState extends State<GroupListScreen> {
+  final GroupsApi api = GroupsApi();
+  late Future<List<dynamic>> _groups;
+
+  @override
+  void initState() {
+    super.initState();
+    _groups = api.fetchGroups();
+  }
+
+  void _refresh() {
+    setState(() {
+      _groups = api.fetchGroups();
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Groups')),
+      body: FutureBuilder<List<dynamic>>(
+        future: _groups,
+        builder: (context, snapshot) {
+          if (snapshot.connectionState != ConnectionState.done) {
+            return const Center(child: CircularProgressIndicator());
+          }
+          if (snapshot.hasError) {
+            return Center(child: Text('Error: ${snapshot.error}'));
+          }
+          final groups = snapshot.data ?? [];
+          if (groups.isEmpty) {
+            return const Center(child: Text('No groups yet'));
+          }
+          return RefreshIndicator(
+            onRefresh: () async => _refresh(),
+            child: ListView.builder(
+              itemCount: groups.length,
+              itemBuilder: (context, index) {
+                final g = groups[index] as Map<String, dynamic>;
+                return ListTile(
+                  title: Text(g['name'] ?? 'Group'),
+                  onTap: () {
+                    Navigator.push(
+                      context,
+                      MaterialPageRoute(
+                        builder: (_) => GroupDetailScreen(groupId: g['id'].toString()),
+                      ),
+                    );
+                  },
+                );
+              },
+            ),
+          );
+        },
+      ),
+      floatingActionButton: FloatingActionButton(
+        onPressed: () async {
+          await Navigator.push(
+            context,
+            MaterialPageRoute(
+              builder: (_) => const GroupCreateJoinScreen(),
+            ),
+          );
+          _refresh();
+        },
+        child: const Icon(Icons.add),
+      ),
+    );
+  }
+}

--- a/frontend/lib/screens/main_layout.dart
+++ b/frontend/lib/screens/main_layout.dart
@@ -1,0 +1,39 @@
+import 'package:flutter/material.dart';
+import 'group_list_screen.dart';
+
+class MainLayout extends StatefulWidget {
+  const MainLayout({super.key});
+
+  @override
+  State<MainLayout> createState() => _MainLayoutState();
+}
+
+class _MainLayoutState extends State<MainLayout> {
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Lunch Recommend')),
+      drawer: Drawer(
+        child: ListView(
+          children: [
+            const DrawerHeader(child: Text('Menu')),
+            ListTile(
+              leading: const Icon(Icons.group),
+              title: const Text('Groups'),
+              onTap: () {
+                Navigator.pop(context);
+                Navigator.push(
+                  context,
+                  MaterialPageRoute(builder: (_) => const GroupListScreen()),
+                );
+              },
+            ),
+          ],
+        ),
+      ),
+      body: const Center(
+        child: Text('Welcome'),
+      ),
+    );
+  }
+}

--- a/frontend/lib/services/apis/groups_api.dart
+++ b/frontend/lib/services/apis/groups_api.dart
@@ -1,0 +1,52 @@
+import 'dart:convert';
+import 'package:http/http.dart' as http;
+
+class GroupsApi {
+  final String baseUrl;
+  GroupsApi({this.baseUrl = '/api'});
+
+  Future<List<dynamic>> fetchGroups() async {
+    final resp = await http.get(Uri.parse('$baseUrl/groups'));
+    if (resp.statusCode != 200) {
+      throw Exception('Failed to load groups');
+    }
+    return jsonDecode(resp.body) as List<dynamic>;
+  }
+
+  Future<Map<String, dynamic>> fetchGroupDetail(String groupId) async {
+    final resp = await http.get(Uri.parse('$baseUrl/groups/$groupId'));
+    if (resp.statusCode != 200) {
+      throw Exception('Group not found');
+    }
+    return jsonDecode(resp.body) as Map<String, dynamic>;
+  }
+
+  Future<Map<String, dynamic>> createGroup(String name) async {
+    final resp = await http.post(
+      Uri.parse('$baseUrl/groups'),
+      headers: {'Content-Type': 'application/json'},
+      body: jsonEncode({'name': name}),
+    );
+    if (resp.statusCode != 201) {
+      throw Exception('Failed to create group');
+    }
+    return jsonDecode(resp.body) as Map<String, dynamic>;
+  }
+
+  Future<Map<String, dynamic>> joinGroup(String inviteCode) async {
+    final resp = await http.post(
+      Uri.parse('$baseUrl/groups/join'),
+      headers: {'Content-Type': 'application/json'},
+      body: jsonEncode({'inviteCode': inviteCode}),
+    );
+    if (resp.statusCode == 404) {
+      throw InvalidInviteCodeException();
+    }
+    if (resp.statusCode != 200) {
+      throw Exception('Failed to join group');
+    }
+    return jsonDecode(resp.body) as Map<String, dynamic>;
+  }
+}
+
+class InvalidInviteCodeException implements Exception {}


### PR DESCRIPTION
## Summary
- add HTTP service for group operations with invalid invite code handling
- implement group list, create/join, and detail screens with role-aware UI
- wire group navigation into the main layout

## Testing
- `cd backend && npm test`
- `cd ../frontend && flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6899a6e8cb00832d90b5a4a8c044747f