### PR TITLE
Add poll creation and voting widgets

### DIFF
--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -9,6 +9,10 @@ import { User } from './entities/user.entity';
 import { FoodsModule } from './foods/foods.module';
 import { PreferencesModule } from './preferences/preferences.module';
 import { AuthModule } from './auth/auth.module';
+import { Poll } from './entities/poll.entity';
+import { PollOption } from './entities/poll-option.entity';
+import { Vote } from './entities/vote.entity';
+import { PollsModule } from './polls/polls.module';
 
 @Module({
   imports: [
@@ -19,13 +23,14 @@ import { AuthModule } from './auth/auth.module';
       username: process.env.DB_USER || 'postgres',
       password: process.env.DB_PASS || 'postgres',
       database: process.env.DB_NAME || 'lunch',
-      entities: [User, Food, Category, FoodCategory, Preference],
+      entities: [User, Food, Category, FoodCategory, Preference, Poll, PollOption, Vote],
       synchronize: true,
     }),
     FoodsModule,
     CategoriesModule,
     PreferencesModule,
     AuthModule,
+    PollsModule,
   ],
 })
 export class AppModule {}

--- a/backend/src/entities/poll-option.entity.ts
+++ b/backend/src/entities/poll-option.entity.ts
@@ -1,0 +1,18 @@
+import { Entity, PrimaryGeneratedColumn, Column, ManyToOne, OneToMany } from 'typeorm';
+import { Poll } from './poll.entity';
+import { Vote } from './vote.entity';
+
+@Entity()
+export class PollOption {
+  @PrimaryGeneratedColumn()
+  id: number;
+
+  @Column()
+  text: string;
+
+  @ManyToOne(() => Poll, (poll) => poll.options, { onDelete: 'CASCADE' })
+  poll: Poll;
+
+  @OneToMany(() => Vote, (vote) => vote.option)
+  votes: Vote[];
+}

--- a/backend/src/entities/poll.entity.ts
+++ b/backend/src/entities/poll.entity.ts
@@ -1,0 +1,17 @@
+import { Entity, PrimaryGeneratedColumn, Column, OneToMany } from 'typeorm';
+import { PollOption } from './poll-option.entity';
+
+@Entity()
+export class Poll {
+  @PrimaryGeneratedColumn()
+  id: number;
+
+  @Column()
+  question: string;
+
+  @Column({ nullable: true })
+  groupId: string;
+
+  @OneToMany(() => PollOption, (option) => option.poll, { cascade: true })
+  options: PollOption[];
+}

--- a/backend/src/entities/vote.entity.ts
+++ b/backend/src/entities/vote.entity.ts
@@ -1,0 +1,15 @@
+import { Entity, PrimaryGeneratedColumn, ManyToOne } from 'typeorm';
+import { User } from './user.entity';
+import { PollOption } from './poll-option.entity';
+
+@Entity()
+export class Vote {
+  @PrimaryGeneratedColumn()
+  id: number;
+
+  @ManyToOne(() => User, { eager: true })
+  user: User;
+
+  @ManyToOne(() => PollOption, (option) => option.votes, { onDelete: 'CASCADE' })
+  option: PollOption;
+}

--- a/backend/src/polls/dto/create-poll.dto.ts
+++ b/backend/src/polls/dto/create-poll.dto.ts
@@ -1,0 +1,5 @@
+export class CreatePollDto {
+  question: string;
+  options: string[];
+  groupId?: string;
+}

--- a/backend/src/polls/dto/vote.dto.ts
+++ b/backend/src/polls/dto/vote.dto.ts
@@ -1,0 +1,3 @@
+export class VoteDto {
+  optionId: number;
+}

--- a/backend/src/polls/polls.controller.ts
+++ b/backend/src/polls/polls.controller.ts
@@ -1,0 +1,47 @@
+import {
+  Body,
+  Controller,
+  Get,
+  Post,
+  Delete,
+  Param,
+  UseGuards,
+  Request,
+} from '@nestjs/common';
+import { PollsService } from './polls.service';
+import { CreatePollDto } from './dto/create-poll.dto';
+import { JwtAuthGuard } from '../auth/jwt-auth.guard';
+import { VoteDto } from './dto/vote.dto';
+
+@Controller('polls')
+export class PollsController {
+  constructor(private readonly pollsService: PollsService) {}
+
+  @UseGuards(JwtAuthGuard)
+  @Post()
+  create(@Body() dto: CreatePollDto) {
+    return this.pollsService.create(dto);
+  }
+
+  @Get(':id')
+  findOne(@Param('id') id: string) {
+    return this.pollsService.findOne(parseInt(id, 10));
+  }
+
+  @UseGuards(JwtAuthGuard)
+  @Post(':id/vote')
+  vote(
+    @Param('id') id: string,
+    @Body() dto: VoteDto,
+    @Request() req,
+  ) {
+    return this.pollsService.vote(parseInt(id, 10), dto.optionId, req.user);
+  }
+
+  @UseGuards(JwtAuthGuard)
+  @Delete(':id/vote')
+  async retract(@Param('id') id: string, @Request() req) {
+    await this.pollsService.retractVote(parseInt(id, 10), req.user);
+    return { success: true };
+  }
+}

--- a/backend/src/polls/polls.module.ts
+++ b/backend/src/polls/polls.module.ts
@@ -1,0 +1,14 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { Poll } from '../entities/poll.entity';
+import { PollOption } from '../entities/poll-option.entity';
+import { Vote } from '../entities/vote.entity';
+import { PollsService } from './polls.service';
+import { PollsController } from './polls.controller';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([Poll, PollOption, Vote])],
+  providers: [PollsService],
+  controllers: [PollsController],
+})
+export class PollsModule {}

--- a/backend/src/polls/polls.service.ts
+++ b/backend/src/polls/polls.service.ts
@@ -1,0 +1,70 @@
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { Poll } from '../entities/poll.entity';
+import { PollOption } from '../entities/poll-option.entity';
+import { Vote } from '../entities/vote.entity';
+import { CreatePollDto } from './dto/create-poll.dto';
+import { User } from '../entities/user.entity';
+
+@Injectable()
+export class PollsService {
+  constructor(
+    @InjectRepository(Poll) private pollRepo: Repository<Poll>,
+    @InjectRepository(PollOption) private optionRepo: Repository<PollOption>,
+    @InjectRepository(Vote) private voteRepo: Repository<Vote>,
+  ) {}
+
+  async create(dto: CreatePollDto): Promise<Poll> {
+    const poll = this.pollRepo.create({
+      question: dto.question,
+      groupId: dto.groupId,
+      options: dto.options.map((text) => ({ text })),
+    });
+    return this.pollRepo.save(poll);
+  }
+
+  async findOne(id: number): Promise<Poll> {
+    return this.pollRepo.findOne({
+      where: { id },
+      relations: ['options', 'options.votes', 'options.votes.user'],
+    });
+  }
+
+  async vote(pollId: number, optionId: number, user: User): Promise<Poll> {
+    const option = await this.optionRepo.findOne({
+      where: { id: optionId },
+      relations: ['poll'],
+    });
+    if (!option || option.poll.id !== pollId) {
+      throw new Error('Invalid option');
+    }
+    let vote = await this.voteRepo.findOne({
+      where: {
+        user: { id: user.id },
+        option: { poll: { id: pollId } },
+      },
+      relations: ['option', 'option.poll', 'user'],
+    });
+    if (vote) {
+      vote.option = option;
+    } else {
+      vote = this.voteRepo.create({ option, user });
+    }
+    await this.voteRepo.save(vote);
+    return this.findOne(pollId);
+  }
+
+  async retractVote(pollId: number, user: User): Promise<void> {
+    const vote = await this.voteRepo.findOne({
+      where: {
+        user: { id: user.id },
+        option: { poll: { id: pollId } },
+      },
+      relations: ['option', 'option.poll', 'user'],
+    });
+    if (vote) {
+      await this.voteRepo.remove(vote);
+    }
+  }
+}

--- a/frontend/lib/screens/group_detail/group_detail_screen.dart
+++ b/frontend/lib/screens/group_detail/group_detail_screen.dart
@@ -1,0 +1,187 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import '../../services/apis/poll_api.dart';
+
+class GroupDetailScreen extends StatefulWidget {
+  final String groupId;
+  final String? token;
+
+  const GroupDetailScreen({super.key, required this.groupId, this.token});
+
+  @override
+  State<GroupDetailScreen> createState() => _GroupDetailScreenState();
+}
+
+class _GroupDetailScreenState extends State<GroupDetailScreen> {
+  Map<String, dynamic>? _poll;
+
+  void _loadPoll(Map<String, dynamic> poll) {
+    setState(() {
+      _poll = poll;
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Group Detail')),
+      body: SingleChildScrollView(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            PollCreationForm(
+              groupId: widget.groupId,
+              token: widget.token,
+              onCreated: _loadPoll,
+            ),
+            const SizedBox(height: 24),
+            if (_poll != null)
+              PollVotingWidget(
+                pollId: _poll!['id'],
+                token: widget.token,
+              ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class PollCreationForm extends StatefulWidget {
+  final String groupId;
+  final String? token;
+  final Function(Map<String, dynamic>) onCreated;
+
+  const PollCreationForm({
+    super.key,
+    required this.groupId,
+    required this.token,
+    required this.onCreated,
+  });
+
+  @override
+  State<PollCreationForm> createState() => _PollCreationFormState();
+}
+
+class _PollCreationFormState extends State<PollCreationForm> {
+  final _questionController = TextEditingController();
+  final List<TextEditingController> _optionControllers = [
+    TextEditingController(),
+    TextEditingController(),
+  ];
+
+  void _addOptionField() {
+    setState(() {
+      _optionControllers.add(TextEditingController());
+    });
+  }
+
+  Future<void> _submit() async {
+    final options =
+        _optionControllers.map((c) => c.text).where((t) => t.isNotEmpty).toList();
+    final poll = await PollApi(widget.token)
+        .createPoll(_questionController.text, options, widget.groupId);
+    widget.onCreated(poll);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        const Text('Start a Poll'),
+        TextField(
+          controller: _questionController,
+          decoration: const InputDecoration(labelText: 'Question'),
+        ),
+        ..._optionControllers
+            .map((c) => TextField(
+                  controller: c,
+                  decoration: const InputDecoration(labelText: 'Option'),
+                ))
+            .toList(),
+        TextButton(onPressed: _addOptionField, child: const Text('Add Option')),
+        ElevatedButton(onPressed: _submit, child: const Text('Create Poll')),
+      ],
+    );
+  }
+}
+
+class PollVotingWidget extends StatefulWidget {
+  final int pollId;
+  final String? token;
+
+  const PollVotingWidget({super.key, required this.pollId, required this.token});
+
+  @override
+  State<PollVotingWidget> createState() => _PollVotingWidgetState();
+}
+
+class _PollVotingWidgetState extends State<PollVotingWidget> {
+  Map<String, dynamic>? _poll;
+  int? _selectedOptionId;
+  Timer? _timer;
+
+  @override
+  void initState() {
+    super.initState();
+    _fetch();
+    _timer = Timer.periodic(const Duration(seconds: 5), (_) => _fetch());
+  }
+
+  @override
+  void dispose() {
+    _timer?.cancel();
+    super.dispose();
+  }
+
+  Future<void> _fetch() async {
+    final poll = await PollApi(widget.token).getPoll(widget.pollId);
+    setState(() {
+      _poll = poll;
+    });
+  }
+
+  Future<void> _vote(int optionId) async {
+    final poll =
+        await PollApi(widget.token).vote(widget.pollId, optionId);
+    setState(() {
+      _poll = poll;
+      _selectedOptionId = optionId;
+    });
+  }
+
+  Future<void> _retract() async {
+    await PollApi(widget.token).retractVote(widget.pollId);
+    setState(() {
+      _selectedOptionId = null;
+    });
+    _fetch();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    if (_poll == null) {
+      return const Center(child: CircularProgressIndicator());
+    }
+    final options = _poll!['options'] as List;
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Text(_poll!['question'] ?? ''),
+        ...options.map((o) {
+          final votes = (o['votes'] as List).length;
+          final isSelected = _selectedOptionId == o['id'];
+          return ListTile(
+            title: Text('${o['text']} ($votes)'),
+            trailing: isSelected ? const Icon(Icons.check) : null,
+            onTap: () => _vote(o['id']),
+          );
+        }),
+        TextButton(onPressed: _retract, child: const Text('Retract Vote')),
+      ],
+    );
+  }
+}

--- a/frontend/lib/services/apis/poll_api.dart
+++ b/frontend/lib/services/apis/poll_api.dart
@@ -1,0 +1,41 @@
+import 'dart:convert';
+import 'package:http/http.dart' as http;
+
+class PollApi {
+  final String? token;
+  final String baseUrl;
+
+  PollApi(this.token, {this.baseUrl = 'http://localhost:3000'});
+
+  Map<String, String> _headers() => {
+        if (token != null) 'Authorization': 'Bearer $token',
+        'Content-Type': 'application/json',
+      };
+
+  Future<Map<String, dynamic>> createPoll(
+      String question, List<String> options, String groupId) async {
+    final res = await http.post(Uri.parse('$baseUrl/polls'),
+        headers: _headers(),
+        body: jsonEncode(
+            {'question': question, 'options': options, 'groupId': groupId}));
+    return jsonDecode(res.body) as Map<String, dynamic>;
+  }
+
+  Future<Map<String, dynamic>> getPoll(int id) async {
+    final res = await http.get(Uri.parse('$baseUrl/polls/$id'),
+        headers: _headers());
+    return jsonDecode(res.body) as Map<String, dynamic>;
+  }
+
+  Future<Map<String, dynamic>> vote(int pollId, int optionId) async {
+    final res = await http.post(Uri.parse('$baseUrl/polls/$pollId/vote'),
+        headers: _headers(),
+        body: jsonEncode({'optionId': optionId}));
+    return jsonDecode(res.body) as Map<String, dynamic>;
+  }
+
+  Future<void> retractVote(int pollId) async {
+    await http.delete(Uri.parse('$baseUrl/polls/$pollId/vote'),
+        headers: _headers());
+  }
+}


### PR DESCRIPTION
## Summary
- add Polls module with creation, voting and retraction endpoints
- integrate poll entities and module into backend app
- build Flutter group detail screen with poll creation form and live voting widget

## Testing
- `cd backend && npm test`
- `cd ../frontend && flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6899a6f72be0832da3263ace2be2bca7