### PR TITLE
chore: add vercel deployment config

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,16 @@
+{
+  "buildCommand": "npm run build:web && npm run build --prefix backend",
+  "outputDirectory": "frontend/build/web",
+  "projects": [
+    {
+      "src": "frontend/build/web",
+      "use": "@vercel/static"
+    }
+  ],
+  "functions": {
+    "api/index.js": {
+      "source": "backend/dist/main.js",
+      "runtime": "nodejs18.x"
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- configure Vercel deployment for frontend and backend

## Testing
- `npm run build --prefix backend` *(fails: Decorators are not valid here)*
- `npm test --prefix backend`

------
https://chatgpt.com/codex/tasks/task_e_6899a7006e6c832d88a4447ea4f61d04