### PR TITLE
Configure Vercel for Flutter web deployment

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,25 @@
+{
+  "version": 2,
+  "public": true,
+  "builds": [
+    { "src": "frontend/build/web/**", "use": "@vercel/static" }
+  ],
+  "routes": [
+    { "handle": "filesystem" },
+    { "src": "/(.*)", "dest": "frontend/build/web/$1" }
+  ],
+  "headers": [
+    {
+      "source": "/(.*)\\.js",
+      "headers": [
+        { "key": "Cache-Control", "value": "public, max-age=31536000, immutable" }
+      ]
+    },
+    {
+      "source": "/(.*)\\.css",
+      "headers": [
+        { "key": "Cache-Control", "value": "public, max-age=31536000, immutable" }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- add `vercel.json` to serve Flutter's `frontend/build/web` output with static routing
- configure long-term caching headers for built JS and CSS assets

## Testing
- `flutter build web --release --pwa-strategy=none` *(fails: command not found)*
- `apt-get install -y flutter` *(fails: Unable to locate package)*
- `npm install -g vercel`
- `vercel --version` *(fails: ENETUNREACH after printing version)*
- `vercel deploy --prebuilt` *(aborts at login prompt)*

------
https://chatgpt.com/codex/tasks/task_e_6899a7040e44832d825ac7e7a41b2c3c