### PR TITLE
Add poll creation and detail screens with voting widgets

### DIFF
--- a/frontend/lib/screens/poll_create_screen.dart
+++ b/frontend/lib/screens/poll_create_screen.dart
@@ -1,0 +1,98 @@
+import 'package:flutter/material.dart';
+import '../services/apis/poll_api.dart';
+
+class PollCreateScreen extends StatefulWidget {
+  final String groupId;
+  const PollCreateScreen({super.key, required this.groupId});
+
+  @override
+  State<PollCreateScreen> createState() => _PollCreateScreenState();
+}
+
+class _PollCreateScreenState extends State<PollCreateScreen> {
+  final PollApi api = PollApi(null);
+  final TextEditingController _questionCtrl = TextEditingController();
+  final List<TextEditingController> _optionCtrls = [
+    TextEditingController(),
+    TextEditingController(),
+  ];
+  bool _loading = false;
+
+  @override
+  void dispose() {
+    _questionCtrl.dispose();
+    for (final c in _optionCtrls) {
+      c.dispose();
+    }
+    super.dispose();
+  }
+
+  void _addOption() {
+    setState(() {
+      _optionCtrls.add(TextEditingController());
+    });
+  }
+
+  Future<void> _create() async {
+    setState(() => _loading = true);
+    try {
+      final options =
+          _optionCtrls.map((c) => c.text).where((s) => s.isNotEmpty).toList();
+      await api.createPoll(_questionCtrl.text, options, widget.groupId);
+      if (!mounted) return;
+      Navigator.pop(context, true);
+    } catch (e) {
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(content: Text('Failed to create poll: $e')),
+        );
+      }
+    } finally {
+      if (mounted) setState(() => _loading = false);
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Create Poll')),
+      body: AbsorbPointer(
+        absorbing: _loading,
+        child: Padding(
+          padding: const EdgeInsets.all(16),
+          child: ListView(
+            children: [
+              TextField(
+                controller: _questionCtrl,
+                decoration: const InputDecoration(labelText: 'Question'),
+              ),
+              const SizedBox(height: 16),
+              ..._optionCtrls.asMap().entries.map((entry) {
+                final index = entry.key;
+                final controller = entry.value;
+                return Padding(
+                  padding: const EdgeInsets.only(bottom: 8),
+                  child: TextField(
+                    controller: controller,
+                    decoration:
+                        InputDecoration(labelText: 'Option ${index + 1}'),
+                  ),
+                );
+              }),
+              TextButton.icon(
+                onPressed: _addOption,
+                icon: const Icon(Icons.add),
+                label: const Text('Add Option'),
+              ),
+              const SizedBox(height: 16),
+              ElevatedButton(
+                onPressed: _create,
+                child: const Text('Create Poll'),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/frontend/lib/screens/poll_detail_screen.dart
+++ b/frontend/lib/screens/poll_detail_screen.dart
@@ -1,0 +1,71 @@
+import 'package:flutter/material.dart';
+import '../services/apis/poll_api.dart';
+import '../widgets/poll_option_list.dart';
+
+class PollDetailScreen extends StatefulWidget {
+  final int pollId;
+  const PollDetailScreen({super.key, required this.pollId});
+
+  @override
+  State<PollDetailScreen> createState() => _PollDetailScreenState();
+}
+
+class _PollDetailScreenState extends State<PollDetailScreen> {
+  final PollApi api = PollApi(null);
+  late Future<Map<String, dynamic>> _poll;
+  int? _selectedOption;
+
+  @override
+  void initState() {
+    super.initState();
+    _poll = api.getPoll(widget.pollId);
+  }
+
+  Future<void> _vote(int optionId) async {
+    await api.vote(widget.pollId, optionId);
+    final data = await api.getPoll(widget.pollId);
+    setState(() {
+      _poll = Future.value(data);
+      _selectedOption = optionId;
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Poll Detail')),
+      body: FutureBuilder<Map<String, dynamic>>(
+        future: _poll,
+        builder: (context, snapshot) {
+          if (snapshot.connectionState != ConnectionState.done) {
+            return const Center(child: CircularProgressIndicator());
+          }
+          if (snapshot.hasError) {
+            return Center(child: Text('Error: ${snapshot.error}'));
+          }
+          final poll = snapshot.data ?? {};
+          final options =
+              (poll['options'] as List<dynamic>? ?? []).cast<Map<String, dynamic>>();
+          return Padding(
+            padding: const EdgeInsets.all(16),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  poll['question'] ?? '',
+                  style: Theme.of(context).textTheme.headlineSmall,
+                ),
+                const SizedBox(height: 16),
+                PollOptionList(
+                  options: options,
+                  onVote: _vote,
+                  selectedOption: _selectedOption,
+                ),
+              ],
+            ),
+          );
+        },
+      ),
+    );
+  }
+}

--- a/frontend/lib/widgets/poll_option_list.dart
+++ b/frontend/lib/widgets/poll_option_list.dart
@@ -1,0 +1,34 @@
+import 'package:flutter/material.dart';
+import 'vote_button.dart';
+
+class PollOptionList extends StatelessWidget {
+  final List<Map<String, dynamic>> options;
+  final int? selectedOption;
+  final void Function(int optionId) onVote;
+
+  const PollOptionList({
+    super.key,
+    required this.options,
+    required this.onVote,
+    this.selectedOption,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      children: options.map((o) {
+        final id = o['id'] as int? ?? 0;
+        final text = o['text'] as String? ?? '';
+        final votes = o['votes'] as List<dynamic>? ?? [];
+        final selected = selectedOption == id;
+        return ListTile(
+          title: Text('$text (${votes.length})'),
+          trailing: VoteButton(
+            selected: selected,
+            onPressed: () => onVote(id),
+          ),
+        );
+      }).toList(),
+    );
+  }
+}

--- a/frontend/lib/widgets/vote_button.dart
+++ b/frontend/lib/widgets/vote_button.dart
@@ -1,0 +1,16 @@
+import 'package:flutter/material.dart';
+
+class VoteButton extends StatelessWidget {
+  final bool selected;
+  final VoidCallback onPressed;
+
+  const VoteButton({super.key, required this.onPressed, this.selected = false});
+
+  @override
+  Widget build(BuildContext context) {
+    return ElevatedButton(
+      onPressed: onPressed,
+      child: Text(selected ? 'Voted' : 'Vote'),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- add poll creation screen for building new polls
- show poll details with option list and voting
- create reusable poll option list and vote button widgets

## Testing
- `npm test --prefix backend`

------
https://chatgpt.com/codex/tasks/task_e_6899b01761b8832dab93cb38781c2aff