### PR TITLE
Add login screen and JWT auth service

### DIFF
--- a/frontend/lib/main.dart
+++ b/frontend/lib/main.dart
@@ -1,17 +1,62 @@
 import 'package:flutter/material.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'screens/login_screen.dart';
 import 'screens/main_layout.dart';
 
 void main() {
   runApp(const MyApp());
 }
 
-class MyApp extends StatelessWidget {
+class MyApp extends StatefulWidget {
   const MyApp({super.key});
 
   @override
+  State<MyApp> createState() => _MyAppState();
+}
+
+class _MyAppState extends State<MyApp> {
+  String? _token;
+  bool _loading = true;
+
+  @override
+  void initState() {
+    super.initState();
+    _loadToken();
+  }
+
+  Future<void> _loadToken() async {
+    final prefs = await SharedPreferences.getInstance();
+    setState(() {
+      _token = prefs.getString('access_token');
+      _loading = false;
+    });
+  }
+
+  void _handleLoggedIn() {
+    _loadToken();
+  }
+
+  Future<void> _logout() async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.remove('access_token');
+    setState(() {
+      _token = null;
+    });
+  }
+
+  @override
   Widget build(BuildContext context) {
-    return const MaterialApp(
-      home: MainLayout(),
+    if (_loading) {
+      return const MaterialApp(
+        home: Scaffold(
+          body: Center(child: CircularProgressIndicator()),
+        ),
+      );
+    }
+    return MaterialApp(
+      home: _token == null
+          ? LoginScreen(onLoggedIn: _handleLoggedIn)
+          : MainLayout(onLogout: _logout),
     );
   }
 }

--- a/frontend/lib/screens/login_screen.dart
+++ b/frontend/lib/screens/login_screen.dart
@@ -1,0 +1,83 @@
+import 'package:flutter/material.dart';
+import '../services/apis/auth_service.dart';
+
+class LoginScreen extends StatefulWidget {
+  final VoidCallback? onLoggedIn;
+  const LoginScreen({super.key, this.onLoggedIn});
+
+  @override
+  State<LoginScreen> createState() => _LoginScreenState();
+}
+
+class _LoginScreenState extends State<LoginScreen> {
+  final _emailCtrl = TextEditingController();
+  final _nicknameCtrl = TextEditingController();
+  final _providerCtrl = TextEditingController(text: 'google');
+  final AuthService _authService = AuthService();
+  bool _loading = false;
+
+  @override
+  void dispose() {
+    _emailCtrl.dispose();
+    _nicknameCtrl.dispose();
+    _providerCtrl.dispose();
+    super.dispose();
+  }
+
+  Future<void> _login() async {
+    setState(() => _loading = true);
+    try {
+      await _authService.login(
+          _emailCtrl.text, _nicknameCtrl.text, _providerCtrl.text);
+      widget.onLoggedIn?.call();
+    } catch (e) {
+      if (!mounted) return;
+      ScaffoldMessenger.of(context)
+          .showSnackBar(SnackBar(content: Text('Login failed: $e')));
+    } finally {
+      if (mounted) setState(() => _loading = false);
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Login')),
+      body: AbsorbPointer(
+        absorbing: _loading,
+        child: Padding(
+          padding: const EdgeInsets.all(16),
+          child: Column(
+            children: [
+              TextField(
+                controller: _emailCtrl,
+                decoration: const InputDecoration(labelText: 'Email'),
+              ),
+              const SizedBox(height: 8),
+              TextField(
+                controller: _nicknameCtrl,
+                decoration: const InputDecoration(labelText: 'Nickname'),
+              ),
+              const SizedBox(height: 8),
+              TextField(
+                controller: _providerCtrl,
+                decoration: const InputDecoration(labelText: 'Provider'),
+              ),
+              const SizedBox(height: 16),
+              ElevatedButton(
+                onPressed: _login,
+                child: _loading
+                    ? const SizedBox(
+                        height: 16,
+                        width: 16,
+                        child: CircularProgressIndicator(strokeWidth: 2),
+                      )
+                    : const Text('Login'),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/frontend/lib/screens/main_layout.dart
+++ b/frontend/lib/screens/main_layout.dart
@@ -2,7 +2,8 @@ import 'package:flutter/material.dart';
 import 'group_list_screen.dart';
 
 class MainLayout extends StatefulWidget {
-  const MainLayout({super.key});
+  final VoidCallback? onLogout;
+  const MainLayout({super.key, this.onLogout});
 
   @override
   State<MainLayout> createState() => _MainLayoutState();
@@ -26,6 +27,14 @@ class _MainLayoutState extends State<MainLayout> {
                   context,
                   MaterialPageRoute(builder: (_) => const GroupListScreen()),
                 );
+              },
+            ),
+            ListTile(
+              leading: const Icon(Icons.logout),
+              title: const Text('Logout'),
+              onTap: () {
+                Navigator.pop(context);
+                widget.onLogout?.call();
               },
             ),
           ],

--- a/frontend/lib/services/apis/auth_service.dart
+++ b/frontend/lib/services/apis/auth_service.dart
@@ -1,0 +1,41 @@
+import 'dart:convert';
+import 'package:http/http.dart' as http;
+import 'package:shared_preferences/shared_preferences.dart';
+
+class AuthService {
+  final String baseUrl;
+  static const _tokenKey = 'access_token';
+
+  AuthService({this.baseUrl = '/api'});
+
+  Future<String> login(
+      String email, String nickname, String socialProvider) async {
+    final res = await http.post(
+      Uri.parse('$baseUrl/auth/login'),
+      headers: {'Content-Type': 'application/json'},
+      body: jsonEncode({
+        'email': email,
+        'nickname': nickname,
+        'socialProvider': socialProvider,
+      }),
+    );
+    if (res.statusCode < 200 || res.statusCode >= 300) {
+      throw Exception('Failed to login');
+    }
+    final data = jsonDecode(res.body) as Map<String, dynamic>;
+    final token = data['accessToken'] as String;
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setString(_tokenKey, token);
+    return token;
+  }
+
+  Future<String?> getToken() async {
+    final prefs = await SharedPreferences.getInstance();
+    return prefs.getString(_tokenKey);
+  }
+
+  Future<void> logout() async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.remove(_tokenKey);
+  }
+}

--- a/frontend/pubspec.yaml
+++ b/frontend/pubspec.yaml
@@ -1,0 +1,19 @@
+name: lunch_recommend_frontend
+description: A simple frontend for lunch recommend app
+version: 0.1.0
+
+environment:
+  sdk: '>=2.17.0 <3.0.0'
+
+dependencies:
+  flutter:
+    sdk: flutter
+  http: ^0.13.0
+  shared_preferences: ^2.0.0
+
+dev_dependencies:
+  flutter_test:
+    sdk: flutter
+
+flutter:
+  uses-material-design: true


### PR DESCRIPTION
## Summary
- add login screen with fields and login button
- implement AuthService to request JWT and save it via SharedPreferences
- manage login state, showing main layout when authenticated and adding logout option

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6899b01e8b68832d8388e60a32f1d34e