### PR TITLE
Add AWS deployment script and document backend environment

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -20,12 +20,30 @@ npm run start:dev
 
 ## Environment Variables
 
-Set the following variables in your environment or Vercel dashboard:
+Configure the backend with the following variables:
 
-- `DATABASE_URL`: PostgreSQL connection string used by TypeORM.
-- `JWT_SECRET`: Secret key for signing JWT tokens.
+- `DATABASE_URL` – full PostgreSQL connection string. If set, the individual `DB_*` variables below are ignored.
+- `DB_HOST` – database host (default `localhost`).
+- `DB_PORT` – database port (default `5432`).
+- `DB_USER` – database user (default `postgres`).
+- `DB_PASS` – database password (default `postgres`).
+- `DB_NAME` – database name (default `lunch`).
+- `JWT_SECRET` – secret key used to sign JWT tokens (**required**).
 
-These must be present for the server to start.
+## Runtime
+
+Start a development server:
+
+```
+npm run start:dev
+```
+
+For production builds:
+
+```
+npm run build
+npm start
+```
 
 ## Docker
 
@@ -42,3 +60,11 @@ docker run -p 3000:3000 lunch-backend
 ```
 
 The API will be available at `http://localhost:3000`.
+
+## AWS Deployment
+
+An example script for deploying the container to AWS Elastic Container Service is provided at [`deploy/aws/deploy.sh`](deploy/aws/deploy.sh). Set the required environment variables described in the script and run:
+
+```
+./deploy/aws/deploy.sh
+```

--- a/backend/deploy/aws/deploy.sh
+++ b/backend/deploy/aws/deploy.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+# Deploy the backend container to AWS Elastic Container Service (ECS).
+#
+# Required environment variables:
+#   AWS_ACCOUNT_ID  - AWS account ID that owns the ECR repository
+#   AWS_REGION      - AWS region (e.g. us-east-1)
+#   ECR_REPOSITORY  - Name of the ECR repository (without registry hostname)
+#   IMAGE_TAG       - Tag to apply to the built image (e.g. latest)
+#   ECS_CLUSTER     - Name of the ECS cluster to update
+#   ECS_SERVICE     - Name of the ECS service to update
+#
+# This script builds the backend Docker image, pushes it to ECR,
+# and triggers a new deployment on the specified ECS service.
+set -euo pipefail
+
+if [[ -z "${AWS_ACCOUNT_ID:-}" || -z "${AWS_REGION:-}" || -z "${ECR_REPOSITORY:-}" || -z "${IMAGE_TAG:-}" || -z "${ECS_CLUSTER:-}" || -z "${ECS_SERVICE:-}" ]]; then
+  echo "One or more required environment variables are missing." >&2
+  exit 1
+fi
+
+REGISTRY="$AWS_ACCOUNT_ID.dkr.ecr.$AWS_REGION.amazonaws.com"
+IMAGE="$REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG"
+
+# Authenticate Docker to ECR
+aws ecr get-login-password --region "$AWS_REGION" |
+  docker login --username AWS --password-stdin "$REGISTRY"
+
+# Build and push the image
+DOCKER_BUILDKIT=1 docker build -t "$IMAGE" ../../..
+docker push "$IMAGE"
+
+# Update the ECS service to use the new image tag
+aws ecs update-service \
+  --cluster "$ECS_CLUSTER" \
+  --service "$ECS_SERVICE" \
+  --force-new-deployment > /dev/null
+
+echo "Deployment triggered for $ECS_SERVICE using image $IMAGE"


### PR DESCRIPTION
## Summary
- add AWS ECS deployment script for backend container
- document environment variables and runtime instructions

## Testing
- `npm test`
- `docker build -t lunch-backend backend/` *(fails: Cannot connect to the Docker daemon at unix:///var/run/docker.sock)*

------
https://chatgpt.com/codex/tasks/task_e_6899b025f7a4832da703da89f17e95af