### PR TITLE
docs: add deployment steps

### DIFF
--- a/frontend/README.md
+++ b/frontend/README.md
@@ -16,3 +16,29 @@ flutter create .
 ```
 
 > Note: Flutter SDK is not installed in this environment. This directory contains a placeholder structure.
+
+## Deployment
+
+To build and host the web app:
+
+1. Install the Flutter SDK and ensure `flutter` is on your `PATH`.
+2. Build the static site:
+
+   ```bash
+   flutter build web
+   ```
+
+   This generates the compiled site in `build/web`.
+3. Install the [Vercel CLI](https://vercel.com/docs/cli):
+
+   ```bash
+   npm install -g vercel
+   ```
+
+4. Deploy the compiled site:
+
+   ```bash
+   vercel deploy --prod build/web
+   ```
+
+   The CLI will prompt you to link a project and will upload the contents of `build/web` to Vercel.


### PR DESCRIPTION
## Summary
- document build and deploy steps for the Flutter web frontend using Vercel

## Testing
- `flutter build web` (fails: command not found)
- `vercel deploy --prod build/web` (requires login)


------
https://chatgpt.com/codex/tasks/task_e_6899b0276c6c832d818f8dd0bedb4eb6