### PR TITLE
Add banner placeholder widget and integrate into major screens

### DIFF
--- a/frontend/README.md
+++ b/frontend/README.md
@@ -16,3 +16,8 @@ flutter create .
 ```
 
 > Note: Flutter SDK is not installed in this environment. This directory contains a placeholder structure.
+
+## Banner Guidelines
+
+- Use `BannerPlaceholder` (`lib/widgets/banner_placeholder.dart`) as the `bottomNavigationBar` of major screens to reserve space for ads.
+- Replace this widget with a real banner implementation when integrating advertising.

--- a/frontend/lib/screens/group_detail/group_detail_screen.dart
+++ b/frontend/lib/screens/group_detail/group_detail_screen.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 
 import 'package:flutter/material.dart';
+import '../../widgets/banner_placeholder.dart';
 import '../../services/apis/poll_api.dart';
 
 class GroupDetailScreen extends StatefulWidget {
@@ -45,6 +46,7 @@ class _GroupDetailScreenState extends State<GroupDetailScreen> {
           ],
         ),
       ),
+      bottomNavigationBar: const BannerPlaceholder(),
     );
   }
 }

--- a/frontend/lib/screens/group_detail_screen.dart
+++ b/frontend/lib/screens/group_detail_screen.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import '../widgets/banner_placeholder.dart';
 import '../services/apis/groups_api.dart';
 
 class GroupDetailScreen extends StatefulWidget {
@@ -60,6 +61,7 @@ class _GroupDetailScreenState extends State<GroupDetailScreen> {
           );
         },
       ),
+      bottomNavigationBar: const BannerPlaceholder(),
     );
   }
 }

--- a/frontend/lib/screens/group_list_screen.dart
+++ b/frontend/lib/screens/group_list_screen.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import '../widgets/banner_placeholder.dart';
 import '../services/apis/groups_api.dart';
 import 'group_detail_screen.dart';
 import 'group_create_join_screen.dart';
@@ -65,6 +66,7 @@ class _GroupListScreenState extends State<GroupListScreen> {
           );
         },
       ),
+      bottomNavigationBar: const BannerPlaceholder(),
       floatingActionButton: FloatingActionButton(
         onPressed: () async {
           await Navigator.push(

--- a/frontend/lib/screens/main_layout.dart
+++ b/frontend/lib/screens/main_layout.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import '../widgets/banner_placeholder.dart';
 import 'group_list_screen.dart';
 
 class MainLayout extends StatefulWidget {
@@ -34,6 +35,7 @@ class _MainLayoutState extends State<MainLayout> {
       body: const Center(
         child: Text('Welcome'),
       ),
+      bottomNavigationBar: const BannerPlaceholder(),
     );
   }
 }

--- a/frontend/lib/widgets/banner_placeholder.dart
+++ b/frontend/lib/widgets/banner_placeholder.dart
@@ -1,0 +1,13 @@
+import 'package:flutter/material.dart';
+
+class BannerPlaceholder extends StatelessWidget {
+  const BannerPlaceholder({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      height: 50,
+      color: Colors.transparent,
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- add `BannerPlaceholder` widget to reserve space for future ads
- use `BannerPlaceholder` as bottom navigation bar on home, group, and poll screens
- document banner usage guidelines in the frontend README

## Testing
- `dart format lib/widgets/banner_placeholder.dart lib/screens/main_layout.dart lib/screens/group_list_screen.dart lib/screens/group_detail_screen.dart lib/screens/group_detail/group_detail_screen.dart README.md` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6899b0295d80832d80d968410557e222