### PR TITLE
feat: list user groups

### DIFF
--- a/backend/src/groups/groups.controller.ts
+++ b/backend/src/groups/groups.controller.ts
@@ -1,5 +1,15 @@
-import { Controller, Post, Body, Get, Param, Delete } from '@nestjs/common';
+import {
+  Controller,
+  Post,
+  Body,
+  Get,
+  Param,
+  Delete,
+  UseGuards,
+  Req,
+} from '@nestjs/common';
 import { GroupsService } from './groups.service';
+import { JwtAuthGuard } from '../auth/jwt-auth.guard';
 
 @Controller('groups')
 export class GroupsController {
@@ -13,6 +23,12 @@ export class GroupsController {
   @Post('join')
   join(@Body('code') code: string, @Body('userId') userId: number) {
     return this.groupsService.join(code, userId);
+  }
+
+  @UseGuards(JwtAuthGuard)
+  @Get()
+  findAll(@Req() req: any) {
+    return this.groupsService.findAllForUser(req.user);
   }
 
   @Get(':id')

--- a/backend/src/groups/groups.service.ts
+++ b/backend/src/groups/groups.service.ts
@@ -33,6 +33,14 @@ export class GroupsService {
     return this.membersRepo.save(member);
   }
 
+  async findAllForUser(user: User): Promise<Group[]> {
+    const memberships = await this.membersRepo.find({
+      where: { user: { id: (user as any).userId } },
+      relations: ['group', 'group.owner'],
+    });
+    return memberships.map((m) => m.group);
+  }
+
   async detail(id: number): Promise<Group | null> {
     return this.groupsRepo.findOne({
       where: { id },


### PR DESCRIPTION
## Summary
- add authenticated groups index endpoint
- retrieve groups for user via memberships

## Testing
- `npm test`
- `npm run build` *(fails: Parameter 'req' implicitly has an 'any' type)*

------
https://chatgpt.com/codex/tasks/task_e_6899b6555934832d8abf0d31a8bf8baa