### PR TITLE
Ensure unique group invitation codes and handle collisions

### DIFF
--- a/backend/src/entities/group.entity.ts
+++ b/backend/src/entities/group.entity.ts
@@ -1,8 +1,16 @@
-import { Entity, PrimaryGeneratedColumn, Column, ManyToOne, OneToMany } from 'typeorm';
+import {
+  Entity,
+  PrimaryGeneratedColumn,
+  Column,
+  ManyToOne,
+  OneToMany,
+  Unique,
+} from 'typeorm';
 import { User } from './user.entity';
 import { GroupMember } from './group-member.entity';
 
 @Entity()
+@Unique(['invitationCode'])
 export class Group {
   @PrimaryGeneratedColumn()
   id!: number;
@@ -10,7 +18,7 @@ export class Group {
   @Column()
   name!: string;
 
-  @Column({ unique: true })
+  @Column()
   invitationCode!: string;
 
   @ManyToOne(() => User, { eager: true })

--- a/backend/src/groups/groups.service.ts
+++ b/backend/src/groups/groups.service.ts
@@ -1,6 +1,6 @@
-import { Injectable } from '@nestjs/common';
+import { ConflictException, Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
-import { Repository } from 'typeorm';
+import { Repository, QueryFailedError } from 'typeorm';
 import { Group } from '../entities/group.entity';
 import { GroupMember } from '../entities/group-member.entity';
 import { User } from '../entities/user.entity';
@@ -18,9 +18,26 @@ export class GroupsService {
 
   async create(name: string, ownerId: number): Promise<Group> {
     const owner = await this.usersRepo.findOneByOrFail({ id: ownerId });
-    const invitationCode = Math.random().toString(36).slice(2, 8);
+
+    let invitationCode: string;
+    do {
+      invitationCode = Math.random().toString(36).slice(2, 8);
+    } while (await this.groupsRepo.exist({ where: { invitationCode } }));
+
     const group = this.groupsRepo.create({ name, owner, invitationCode });
-    await this.groupsRepo.save(group);
+
+    try {
+      await this.groupsRepo.save(group);
+    } catch (err) {
+      if (
+        err instanceof QueryFailedError &&
+        (err as any).driverError?.code === '23505'
+      ) {
+        throw new ConflictException('Invitation code already exists');
+      }
+      throw err;
+    }
+
     const membership = this.membersRepo.create({ group, user: owner, role: 'owner' });
     await this.membersRepo.save(membership);
     return group;

--- a/backend/src/polls/polls.controller.ts
+++ b/backend/src/polls/polls.controller.ts
@@ -33,14 +33,14 @@ export class PollsController {
   vote(
     @Param('id') id: string,
     @Body() dto: VoteDto,
-    @Request() req,
+    @Request() req: any,
   ) {
     return this.pollsService.vote(parseInt(id, 10), dto.optionId, req.user);
   }
 
   @UseGuards(JwtAuthGuard)
   @Delete(':id/vote')
-  async retract(@Param('id') id: string, @Request() req) {
+  async retract(@Param('id') id: string, @Request() req: any) {
     await this.pollsService.retractVote(parseInt(id, 10), req.user);
     return { success: true };
   }


### PR DESCRIPTION
## Summary
- Enforce uniqueness of group invitation codes via a class-level constraint
- Retry invitation code generation until it is unique and raise a conflict on persistence failure
- Type poll controller request parameters to allow TypeScript compilation

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6899b6568e04832d9ae0f1c263263389