### PR TITLE
Add poll screens and integrate with group details

### DIFF
--- a/frontend/lib/screens/group_detail_screen.dart
+++ b/frontend/lib/screens/group_detail_screen.dart
@@ -1,6 +1,8 @@
+import 'dart:async';
 import 'package:flutter/material.dart';
 import '../widgets/banner_placeholder.dart';
 import '../services/apis/groups_api.dart';
+import '../services/apis/poll_api.dart';
 
 class GroupDetailScreen extends StatefulWidget {
   final String groupId;
@@ -13,6 +15,13 @@ class GroupDetailScreen extends StatefulWidget {
 class _GroupDetailScreenState extends State<GroupDetailScreen> {
   final GroupsApi api = GroupsApi();
   late Future<Map<String, dynamic>> _group;
+  int? _pollId;
+
+  void _onPollCreated(Map<String, dynamic> poll) {
+    setState(() {
+      _pollId = poll['id'] as int?;
+    });
+  }
 
   @override
   void initState() {
@@ -47,6 +56,16 @@ class _GroupDetailScreenState extends State<GroupDetailScreen> {
               Text('Members', style: Theme.of(context).textTheme.titleMedium),
               ...members.map((m) => ListTile(title: Text(m['name'] ?? 'Member'))),
               const SizedBox(height: 24),
+              PollCreationForm(
+                groupId: widget.groupId,
+                onCreated: _onPollCreated,
+              ),
+              const SizedBox(height: 24),
+              if (_pollId != null)
+                PollStatusWidget(
+                  pollId: _pollId!,
+                ),
+              const SizedBox(height: 24),
               if (isOwner)
                 ElevatedButton(
                   onPressed: () {},
@@ -62,6 +81,118 @@ class _GroupDetailScreenState extends State<GroupDetailScreen> {
         },
       ),
       bottomNavigationBar: const BannerPlaceholder(),
+    );
+  }
+}
+
+class PollCreationForm extends StatefulWidget {
+  final String groupId;
+  final void Function(Map<String, dynamic>) onCreated;
+
+  const PollCreationForm({
+    super.key,
+    required this.groupId,
+    required this.onCreated,
+  });
+
+  @override
+  State<PollCreationForm> createState() => _PollCreationFormState();
+}
+
+class _PollCreationFormState extends State<PollCreationForm> {
+  final _questionController = TextEditingController();
+  final List<TextEditingController> _optionControllers = [
+    TextEditingController(),
+    TextEditingController(),
+  ];
+
+  void _addOptionField() {
+    setState(() {
+      _optionControllers.add(TextEditingController());
+    });
+  }
+
+  Future<void> _submit() async {
+    final options =
+        _optionControllers.map((c) => c.text).where((t) => t.isNotEmpty).toList();
+    final poll = await PollApi(null)
+        .createPoll(_questionController.text, options, widget.groupId);
+    widget.onCreated(poll);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        const Text('Start a Poll'),
+        TextField(
+          controller: _questionController,
+          decoration: const InputDecoration(labelText: 'Question'),
+        ),
+        ..._optionControllers
+            .map((c) => TextField(
+                  controller: c,
+                  decoration: const InputDecoration(labelText: 'Option'),
+                ))
+            .toList(),
+        TextButton(onPressed: _addOptionField, child: const Text('Add Option')),
+        ElevatedButton(onPressed: _submit, child: const Text('Create Poll')),
+      ],
+    );
+  }
+}
+
+class PollStatusWidget extends StatefulWidget {
+  final int pollId;
+
+  const PollStatusWidget({super.key, required this.pollId});
+
+  @override
+  State<PollStatusWidget> createState() => _PollStatusWidgetState();
+}
+
+class _PollStatusWidgetState extends State<PollStatusWidget> {
+  Map<String, dynamic>? _poll;
+  Timer? _timer;
+
+  @override
+  void initState() {
+    super.initState();
+    _fetch();
+    _timer = Timer.periodic(const Duration(seconds: 5), (_) => _fetch());
+  }
+
+  @override
+  void dispose() {
+    _timer?.cancel();
+    super.dispose();
+  }
+
+  Future<void> _fetch() async {
+    final poll = await PollApi(null).getResults(widget.pollId);
+    setState(() {
+      _poll = poll;
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    if (_poll == null) {
+      return const Center(child: CircularProgressIndicator());
+    }
+    final options = _poll!['options'] as List<dynamic>? ?? [];
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Text(_poll!['question'] ?? ''),
+        ...options.map((o) {
+          final votes = (o['votes'] as List<dynamic>? ?? []).length;
+          return ListTile(
+            title: Text('${o['text']} ($votes)'),
+          );
+        }),
+      ],
     );
   }
 }

--- a/frontend/lib/screens/polls/poll_options_screen.dart
+++ b/frontend/lib/screens/polls/poll_options_screen.dart
@@ -1,0 +1,71 @@
+import 'package:flutter/material.dart';
+import '../../services/apis/poll_api.dart';
+import '../../widgets/poll_option_list.dart';
+
+class PollOptionsScreen extends StatefulWidget {
+  final int pollId;
+  const PollOptionsScreen({super.key, required this.pollId});
+
+  @override
+  State<PollOptionsScreen> createState() => _PollOptionsScreenState();
+}
+
+class _PollOptionsScreenState extends State<PollOptionsScreen> {
+  final PollApi api = PollApi(null);
+  late Future<Map<String, dynamic>> _poll;
+  int? _selectedOption;
+
+  @override
+  void initState() {
+    super.initState();
+    _poll = api.getOptions(widget.pollId);
+  }
+
+  Future<void> _vote(int optionId) async {
+    await api.vote(widget.pollId, optionId);
+    final data = await api.getOptions(widget.pollId);
+    setState(() {
+      _poll = Future.value(data);
+      _selectedOption = optionId;
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Poll Options')),
+      body: FutureBuilder<Map<String, dynamic>>(
+        future: _poll,
+        builder: (context, snapshot) {
+          if (snapshot.connectionState != ConnectionState.done) {
+            return const Center(child: CircularProgressIndicator());
+          }
+          if (snapshot.hasError) {
+            return Center(child: Text('Error: ${snapshot.error}'));
+          }
+          final poll = snapshot.data ?? {};
+          final options =
+              (poll['options'] as List<dynamic>? ?? []).cast<Map<String, dynamic>>();
+          return Padding(
+            padding: const EdgeInsets.all(16),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  poll['question'] ?? '',
+                  style: Theme.of(context).textTheme.headlineSmall,
+                ),
+                const SizedBox(height: 16),
+                PollOptionList(
+                  options: options,
+                  onVote: _vote,
+                  selectedOption: _selectedOption,
+                ),
+              ],
+            ),
+          );
+        },
+      ),
+    );
+  }
+}

--- a/frontend/lib/screens/polls/poll_results_screen.dart
+++ b/frontend/lib/screens/polls/poll_results_screen.dart
@@ -1,0 +1,66 @@
+import 'dart:async';
+import 'package:flutter/material.dart';
+import '../../services/apis/poll_api.dart';
+
+class PollResultsScreen extends StatefulWidget {
+  final int pollId;
+  const PollResultsScreen({super.key, required this.pollId});
+
+  @override
+  State<PollResultsScreen> createState() => _PollResultsScreenState();
+}
+
+class _PollResultsScreenState extends State<PollResultsScreen> {
+  final PollApi api = PollApi(null);
+  Map<String, dynamic>? _poll;
+  Timer? _timer;
+
+  @override
+  void initState() {
+    super.initState();
+    _fetch();
+    _timer = Timer.periodic(const Duration(seconds: 5), (_) => _fetch());
+  }
+
+  @override
+  void dispose() {
+    _timer?.cancel();
+    super.dispose();
+  }
+
+  Future<void> _fetch() async {
+    final poll = await api.getResults(widget.pollId);
+    setState(() {
+      _poll = poll;
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Live Results')),
+      body: _poll == null
+          ? const Center(child: CircularProgressIndicator())
+          : Padding(
+              padding: const EdgeInsets.all(16),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text(
+                    _poll!['question'] ?? '',
+                    style: Theme.of(context).textTheme.headlineSmall,
+                  ),
+                  const SizedBox(height: 16),
+                  ...((_poll!['options'] as List<dynamic>? ?? [])).map((o) {
+                    final text = o['text'] as String? ?? '';
+                    final votes = (o['votes'] as List<dynamic>? ?? []).length;
+                    return ListTile(
+                      title: Text('$text ($votes)'),
+                    );
+                  }),
+                ],
+              ),
+            ),
+    );
+  }
+}

--- a/frontend/lib/screens/polls/poll_start_screen.dart
+++ b/frontend/lib/screens/polls/poll_start_screen.dart
@@ -1,0 +1,97 @@
+import 'package:flutter/material.dart';
+import '../../services/apis/poll_api.dart';
+
+class PollStartScreen extends StatefulWidget {
+  final String groupId;
+  const PollStartScreen({super.key, required this.groupId});
+
+  @override
+  State<PollStartScreen> createState() => _PollStartScreenState();
+}
+
+class _PollStartScreenState extends State<PollStartScreen> {
+  final PollApi api = PollApi(null);
+  final TextEditingController _questionCtrl = TextEditingController();
+  final List<TextEditingController> _optionCtrls = [
+    TextEditingController(),
+    TextEditingController(),
+  ];
+  bool _loading = false;
+
+  @override
+  void dispose() {
+    _questionCtrl.dispose();
+    for (final c in _optionCtrls) {
+      c.dispose();
+    }
+    super.dispose();
+  }
+
+  void _addOption() {
+    setState(() {
+      _optionCtrls.add(TextEditingController());
+    });
+  }
+
+  Future<void> _create() async {
+    setState(() => _loading = true);
+    try {
+      final options =
+          _optionCtrls.map((c) => c.text).where((s) => s.isNotEmpty).toList();
+      await api.createPoll(_questionCtrl.text, options, widget.groupId);
+      if (!mounted) return;
+      Navigator.pop(context, true);
+    } catch (e) {
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(content: Text('Failed to create poll: $e')),
+        );
+      }
+    } finally {
+      if (mounted) setState(() => _loading = false);
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Start Poll')),
+      body: AbsorbPointer(
+        absorbing: _loading,
+        child: Padding(
+          padding: const EdgeInsets.all(16),
+          child: ListView(
+            children: [
+              TextField(
+                controller: _questionCtrl,
+                decoration: const InputDecoration(labelText: 'Question'),
+              ),
+              const SizedBox(height: 16),
+              ..._optionCtrls.asMap().entries.map((entry) {
+                final index = entry.key;
+                final controller = entry.value;
+                return Padding(
+                  padding: const EdgeInsets.only(bottom: 8),
+                  child: TextField(
+                    controller: controller,
+                    decoration: InputDecoration(labelText: 'Option ${index + 1}'),
+                  ),
+                );
+              }),
+              TextButton.icon(
+                onPressed: _addOption,
+                icon: const Icon(Icons.add),
+                label: const Text('Add Option'),
+              ),
+              const SizedBox(height: 16),
+              ElevatedButton(
+                onPressed: _create,
+                child: const Text('Create Poll'),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/frontend/lib/services/apis/poll_api.dart
+++ b/frontend/lib/services/apis/poll_api.dart
@@ -38,4 +38,16 @@ class PollApi {
     await http.delete(Uri.parse('$baseUrl/polls/$pollId/vote'),
         headers: _headers());
   }
+
+  Future<Map<String, dynamic>> getOptions(int pollId) async {
+    final res = await http.get(Uri.parse('$baseUrl/polls/$pollId/options'),
+        headers: _headers());
+    return jsonDecode(res.body) as Map<String, dynamic>;
+  }
+
+  Future<Map<String, dynamic>> getResults(int pollId) async {
+    final res = await http.get(Uri.parse('$baseUrl/polls/$pollId/results'),
+        headers: _headers());
+    return jsonDecode(res.body) as Map<String, dynamic>;
+  }
 }


### PR DESCRIPTION
## Summary
- add poll start, options, and live results screens
- extend PollApi with new endpoints for options and results
- embed poll creation and live status components in group detail view

## Testing
- `dart format lib/screens/polls/poll_start_screen.dart lib/screens/polls/poll_options_screen.dart lib/screens/polls/poll_results_screen.dart lib/services/apis/poll_api.dart lib/screens/group_detail_screen.dart` *(fails: command not found)*
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6899b6582b14832dba7ce4a40f96e87d